### PR TITLE
Saves migration contents in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ module.exports = {
   changelogCollectionName: "changelog",
 
   // The file extension to create migrations and search for in migration dir 
-  migrationFileExtension: ".js"
+  migrationFileExtension: ".js",
 
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
-  useFileHash: false
+  useFileHash: false,
+
+  // Enable the algorithm to save a copy of the file contents and use that content for down migrations
+  saveFileContents: false
 };
 ````
 
@@ -321,6 +324,16 @@ Now the status will also include the file hash in the output
 │ 20160608155948-blacklist_the_beatles.js│ 7625a0220d552dbeb42e26fdab61d8c7ef54ac3a052254588c267e42e9fa876d │ 2021-03-04T15:40:22.732Z │
 └────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┴──────────────────────────┘
 
+```
+
+### Save the contents of the migration script to the database
+If we are rolling back our code, the file with the migration may not be available. In that case we 
+would not be able to undo the database changes by running the `down()` method. If we
+enable this option, the contents of the migration file will be saved into the database
+and will be used to run the down migrations
+
+```javascript
+saveFileContents: true
 ```
 
 ### Version

--- a/lib/actions/down.js
+++ b/lib/actions/down.js
@@ -9,12 +9,18 @@ const hasCallback = require('../utils/has-callback');
 
 module.exports = async (db, client) => {
   const downgraded = [];
-  const statusItems = await status(db);
+  const { saveFileContents, changelogCollectionName } = await config.read();
+  const changelogCollection = db.collection(changelogCollectionName);
+  const statusItems = await status(db, saveFileContents);
   const appliedItems = statusItems.filter(item => item.appliedAt !== "PENDING");
   const lastAppliedItem = _.last(appliedItems);
 
   if (lastAppliedItem) {
     try {
+      if (saveFileContents) {
+        const savedItem = await changelogCollection.findOne({ fileName: lastAppliedItem.fileName });
+        await migrationsDir.writeFileContents(lastAppliedItem.fileName, savedItem.fileContents);
+      }
       const migration = await migrationsDir.loadMigration(lastAppliedItem.fileName);
       const down = hasCallback(migration.down) ? promisify(migration.down) : migration.down;
 
@@ -30,8 +36,6 @@ module.exports = async (db, client) => {
         `Could not migrate down ${lastAppliedItem.fileName}: ${err.message}`
       );
     }
-    const { changelogCollectionName } = await config.read();
-    const changelogCollection = db.collection(changelogCollectionName);
     try {
       await changelogCollection.deleteOne({ fileName: lastAppliedItem.fileName });
       downgraded.push(lastAppliedItem.fileName);

--- a/lib/actions/status.js
+++ b/lib/actions/status.js
@@ -2,28 +2,50 @@ const { find } = require("lodash");
 const migrationsDir = require("../env/migrationsDir");
 const config = require("../env/config");
 
-module.exports = async db => {
+module.exports = async (db, shouldLoadFromDatabase) => {
   await migrationsDir.shouldExist();
   await config.shouldExist();
   const fileNames = await migrationsDir.getFileNames();
 
-  const { changelogCollectionName, useFileHash } = await config.read();
+  const { changelogCollectionName, useFileHash, saveFileContents } = await config.read();
   const changelogCollection = db.collection(changelogCollectionName);
   const changelog = await changelogCollection.find({}).toArray();
-
 
   const useFileHashTest = useFileHash === true;
   const statusTable = await Promise.all(fileNames.map(async (fileName) => {
     let fileHash;
-    let findTest = { fileName };
+    const findTest = { fileName };
     if (useFileHashTest) {
       fileHash = await migrationsDir.loadFileHash(fileName);
-      findTest = { fileName, fileHash };
+      findTest.fileHash = fileHash;
     }
     const itemInLog = find(changelog, findTest);
-    const appliedAt = itemInLog ? itemInLog.appliedAt.toJSON() : "PENDING";
-    return useFileHash ? { fileName, fileHash, appliedAt } : { fileName, appliedAt };
+    if (itemInLog) {
+      const indexInLog = changelog.indexOf(itemInLog);
+      changelog.splice(indexInLog, 1);
+    }
+    findTest.appliedAt = itemInLog ? itemInLog.appliedAt.toJSON() : "PENDING";
+    if (saveFileContents) {
+      const fileContents = await migrationsDir.loadFileContents(fileName);
+      findTest.fileContents = fileContents.toString();
+    }
+    return findTest;
   }));
+
+  // if we have saved migrations in the database, we need to add any migration which is in the database without a file
+  if (shouldLoadFromDatabase === true) {
+    changelog.forEach(migrationInDb => {
+      const migration = {
+        fileName: migrationInDb.fileName,
+      }
+      if (migrationInDb.fileHash) {
+        migration.fileHash = migrationInDb.fileHash;
+      }
+      migration.appliedAt = migrationInDb.appliedAt.toJSON();
+      migration.fileContents = migrationInDb.fileContents;
+      statusTable.push(migration);
+    });
+  }
 
   return statusTable;
 };

--- a/lib/actions/up.js
+++ b/lib/actions/up.js
@@ -34,14 +34,21 @@ module.exports = async (db, client) => {
       throw error;
     }
 
-    const { changelogCollectionName, useFileHash } = await config.read();
+    const { changelogCollectionName, useFileHash, saveFileContents } = await config.read();
     const changelogCollection = db.collection(changelogCollectionName);
 
-    const { fileName, fileHash } = item;
+    const { fileName, fileHash, fileContents } = item;
     const appliedAt = new Date();
 
     try {
-      await changelogCollection.insertOne(useFileHash === true ? { fileName, fileHash, appliedAt } : { fileName, appliedAt });
+      const migration = { fileName, appliedAt };
+      if (useFileHash) {
+        migration.fileHash = fileHash;
+      }
+      if (saveFileContents) {
+        migration.fileContents = fileContents;
+      }
+      await changelogCollection.insertOne(migration);
     } catch (err) {
       throw new Error(`Could not update changelog: ${err.message}`);
     }

--- a/lib/env/migrationsDir.js
+++ b/lib/env/migrationsDir.js
@@ -106,6 +106,18 @@ module.exports = {
     return hash.digest('hex');
   },
 
+  async loadFileContents(fileName) {
+    const migrationsDir = await resolveMigrationsDirPath();
+    const filePath = path.join(migrationsDir, fileName)
+    return fs.readFile(filePath);
+  },
+
+  async writeFileContents(fileName, contents) {
+    const migrationsDir = await resolveMigrationsDirPath();
+    const filePath = path.join(migrationsDir, fileName)
+    return fs.writeFile(filePath, contents);
+  },
+
   async doesSampleMigrationExist() {
     const samplePath = await resolveSampleMigrationPath();
     try {

--- a/samples/migrate-mongo-config.js
+++ b/samples/migrate-mongo-config.js
@@ -27,7 +27,10 @@ const config = {
 
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
-  useFileHash: false
+  useFileHash: false,
+
+  // Enable the algorithm to save a copy of the file contents and use that content for down migrations
+  saveFileContents: false
 };
 
 // Return the config as a promise

--- a/test/actions/down.test.js
+++ b/test/actions/down.test.js
@@ -37,7 +37,8 @@ describe("down", () => {
 
   function mockMigrationsDir() {
     return {
-      loadMigration: sinon.stub().returns(Promise.resolve(migration))
+      loadMigration: sinon.stub().returns(Promise.resolve(migration)),
+      writeFileContents: sinon.stub().returns(Promise.resolve(true))
     };
   }
 
@@ -62,7 +63,8 @@ describe("down", () => {
 
   function mockChangelogCollection() {
     return {
-      deleteOne: sinon.stub().returns(Promise.resolve())
+      deleteOne: sinon.stub().returns(Promise.resolve()),
+      findOne: sinon.stub().returns(Promise.resolve(migration))
     };
   }
 
@@ -176,6 +178,15 @@ describe("down", () => {
   });
 
   it("should yield a list of downgraded items", async () => {
+    const items = await down(db);
+    expect(items).to.deep.equal(["20160609113225-last_migration.js"]);
+  });
+
+  it("should yield a list of downgraded items when used saved file contents", async () => {
+    config.read.returns({
+      changelogCollectionName: "changelog",
+      saveFileContents: true
+    })
     const items = await down(db);
     expect(items).to.deep.equal(["20160609113225-last_migration.js"]);
   });

--- a/test/actions/status.test.js
+++ b/test/actions/status.test.js
@@ -37,6 +37,20 @@ describe("status", () => {
               return Promise.resolve();
           }
         }),
+      loadFileContents: sinon
+        .stub()
+        .callsFake((fileName) => {
+          switch (fileName) {
+            case "20160509113224-first_migration.js":
+              return Promise.resolve("Contents of first migration");
+            case "20160512091701-second_migration.js":
+              return Promise.resolve("Contents of second migration");
+            case "20160513155321-third_migration.js":
+              return Promise.resolve("Contents of third migration");
+            default:
+              return Promise.resolve();
+          }
+        }),
     };
   }
 
@@ -87,6 +101,21 @@ describe("status", () => {
     configContent.read.returns({
       changelogCollectionName: "changelog",
       useFileHash: true
+    })
+  }
+
+  function enabledSaveFileContents(configContent) {
+    configContent.read.returns({
+      changelogCollectionName: "changelog",
+      saveFileContents: true
+    })
+  }
+
+  function enabledFileHashAndSaveFileContents(configContent) {
+    configContent.read.returns({
+      changelogCollectionName: "changelog",
+      useFileHash: true,
+      saveFileContents: true
     })
   }
 
@@ -292,4 +321,195 @@ describe("status", () => {
       }
     ]);
   });
+
+  it("it should load the file contents when save file contents is set to true", async () => {
+    enabledSaveFileContents(config);
+    const statusItems = await status(db, true);
+    expect(statusItems).to.deep.equal([
+      {
+        appliedAt: "2016-06-03T20:10:12.123Z",
+        fileName: "20160509113224-first_migration.js",
+        fileContents: "Contents of first migration",
+      },
+      {
+        appliedAt: "2016-06-09T20:10:12.123Z",
+        fileName: "20160512091701-second_migration.js",
+        fileContents: "Contents of second migration",
+      },
+      {
+        appliedAt: "PENDING",
+        fileName: "20160513155321-third_migration.js",
+        fileContents: "Contents of third migration",
+      }
+    ]);
+  });
+
+  it("it should load the file contents and the file hash if both settings are set to true", async () => {
+    enabledFileHashAndSaveFileContents(config);
+    addHashToChangeLog(changelogCollection);
+    const statusItems = await status(db, true);
+    expect(statusItems).to.deep.equal([
+      {
+        appliedAt: "2016-06-03T20:10:12.123Z",
+        fileName: "20160509113224-first_migration.js",
+        fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+        fileContents: "Contents of first migration",
+      },
+      {
+        appliedAt: "2016-06-09T20:10:12.123Z",
+        fileName: "20160512091701-second_migration.js",
+        fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff70",
+        fileContents: "Contents of second migration",
+      },
+      {
+        appliedAt: "PENDING",
+        fileName: "20160513155321-third_migration.js",
+        fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+        fileContents: "Contents of third migration",
+      }
+    ]);
+  });
+
+  it("it should load the file contents from the database if the file no longer exists", async () => {
+    enabledSaveFileContents(config);
+
+    migrationsDir.getFileNames.returns([
+      "20160509113224-first_migration.js",
+    ]);
+
+    migrationsDir.loadFileContents.callsFake((fileName) => {
+      switch (fileName) {
+        case "20160509113224-first_migration.js":
+          return Promise.resolve("Contents of first migration");
+        default:
+          return Promise.resolve();
+      }
+    })
+
+    migrationsDir.loadFileHash.callsFake((fileName) => {
+      switch (fileName) {
+        case "20160509113224-first_migration.js":
+          return Promise.resolve("0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a");
+        default:
+          return Promise.resolve();
+      }
+    })
+
+    changelogCollection.find.returns({
+      toArray: sinon.stub().returns(
+        Promise.resolve([
+          {
+            fileName: "20160509113224-first_migration.js",
+            fileContents: "Contents of first migration",
+            appliedAt: new Date("2016-06-03T20:10:12.123Z")
+          },
+          {
+            fileName: "20160512091701-second_migration.js",
+            fileContents: "Contents of second migration",
+            appliedAt: new Date("2016-06-09T20:10:12.123Z")
+          }
+        ])
+      )
+    })
+
+    const statusItems = await status(db, true);
+    expect(statusItems).to.deep.equal([
+      {
+        appliedAt: "2016-06-03T20:10:12.123Z",
+        fileName: "20160509113224-first_migration.js",
+        fileContents: "Contents of first migration",
+      },
+      {
+        appliedAt: "2016-06-09T20:10:12.123Z",
+        fileName: "20160512091701-second_migration.js",
+        fileContents: "Contents of second migration",
+      }
+    ]);
+  });
+
+  it("it should load the file contents from both the database and the file system if hashes don't match", async () => {
+    enabledFileHashAndSaveFileContents(config);
+    addHashToChangeLog(changelogCollection);
+
+    migrationsDir.getFileNames.returns([
+      "20160509113224-first_migration.js",
+      "20160512091701-second_migration.js",
+    ]);
+
+    migrationsDir.loadFileContents.callsFake((fileName) => {
+      switch (fileName) {
+        case "20160509113224-first_migration.js":
+          return Promise.resolve("Contents of first migration");
+        case "20160512091701-second_migration.js":
+          return Promise.resolve("Contents of second migration");
+        default:
+          return Promise.resolve();
+      }
+    })
+
+    changelogCollection.find.returns({
+      toArray: sinon.stub().returns(
+        Promise.resolve([
+          {
+            fileName: "20160509113224-first_migration.js",
+            fileContents: "Contents of first migration",
+            fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+            appliedAt: new Date("2016-06-03T20:10:12.123Z")
+          },
+          {
+            fileName: "20160512091701-second_migration.js",
+            fileContents: "Other contents of second migration",
+            fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff70",
+            appliedAt: new Date("2016-06-09T20:10:12.123Z")
+          },
+          {
+            fileName: "20160513155321-third_migration.js",
+            fileContents: "Contents of third migration",
+            fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+            appliedAt: new Date("2016-06-20T20:10:12.123Z")
+          }
+        ])
+      )
+    })
+
+    migrationsDir.loadFileHash.callsFake((fileName) => {
+      switch (fileName) {
+        case "20160509113224-first_migration.js":
+          return Promise.resolve("0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a");
+        case "20160512091701-second_migration.js":
+          return Promise.resolve("18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97aaaaaaa");
+        default:
+          return Promise.resolve();
+      }
+    })
+
+    const statusItems = await status(db, true);
+    expect(statusItems).to.deep.equal([
+      {
+        appliedAt: "2016-06-03T20:10:12.123Z",
+        fileName: "20160509113224-first_migration.js",
+        fileHash: "0f295f21f63c66dc78d8dc091ce3c8bab8c56d8b74fb35a0c99f6d9953e37d1a",
+        fileContents: "Contents of first migration",
+      },
+      {
+        appliedAt: "PENDING",
+        fileName: "20160512091701-second_migration.js",
+        fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97aaaaaaa",
+        fileContents: "Contents of second migration",
+      },
+      {
+        appliedAt: "2016-06-09T20:10:12.123Z",
+        fileName: "20160512091701-second_migration.js",
+        fileHash: "18b4d9c95a8678ae3a6dd3ae5b8961737a6c3dd65e3e655a5f5718d97a0bff70",
+        fileContents: "Other contents of second migration",
+      },
+      {
+        appliedAt: "2016-06-20T20:10:12.123Z",
+        fileName: "20160513155321-third_migration.js",
+        fileHash: "1f9eb3b5eb70b2fb5b83fa0c660d859082f0bb615e835d29943d26fb0d352022",
+        fileContents: "Contents of third migration",
+      }
+    ]);
+  });
+
 });

--- a/test/env/migrationsDir.test.js
+++ b/test/env/migrationsDir.test.js
@@ -13,7 +13,8 @@ describe("migrationsDir", () => {
     return {
       stat: sinon.stub(),
       readdir: sinon.stub(),
-      readFile: sinon.stub()
+      readFile: sinon.stub(),
+      writeFile: sinon.stub()
     };
   }
 
@@ -222,6 +223,22 @@ describe("migrationsDir", () => {
       fs.readFile.returns(Promise.resolve("some string to hash"));
       const result = await migrationsDir.loadFileHash('somefile.js');
       expect(result).to.equal("ea83a45637a9af470a994d2c9722273ef07d47aec0660a1d10afe6e9586801ac");
+    })
+  })
+
+  describe("loadFileContents()", () => {
+    it("should return the content of a file contents", async () => {
+      fs.readFile.returns(Promise.resolve('the content of some file'));
+      const result = await migrationsDir.loadFileContents('somefile.js');
+      expect(result).to.equal('the content of some file');
+    })
+  })
+
+  describe("writeFileContents()", () => {
+    it("should write a string to a file", async () => {
+      fs.writeFile.returns(Promise.resolve(true));
+      const result = await migrationsDir.writeFileContents('somefile.js', 'some content');
+      expect(result).to.equal(true);
     })
   })
 });


### PR DESCRIPTION
If we are rolling back our code, the file with the migration may not be available. In that case we would not be able to undo the database changes by running the `down()` method. This PR has a new `saveFileContents` option to the config. If we enable this option, the contents of the migration file will be saved into the database and will be used to run the down migrations.

See the comments in the PR for more info
